### PR TITLE
feat: add authorGroupLogo property

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ interface ConfigJson {
 	 * @example ["solvedDev", "Joel ant 05"]
 	 */
 	authors: string[]
+	/**
+	 * A path relative to the project roots that points to a logo representing the author group
+	 *
+	 * @example "./my-logo.png"
+	 */
+	authorGroupLogo?: string
 
 	/**
 	 * The Minecraft version this project targets
@@ -76,7 +82,6 @@ interface ConfigJson {
 		names: PackDefinition
 	}
 
-
 	/**
 	 * Tools can create their own namespace inside of this file to save tool specific data and settings
 	 *
@@ -119,6 +124,8 @@ A common project structure for a Minecraft Bedrock project following this standa
 The specification only handles the config.json file at the root of the project. The exact folder names of individual packs can change based on its content.
 
 ## Reserved Tool IDs
+
 The following tool identifiers are already in use:
-- "bridge"
-- "compiler"
+
+-   "bridge"
+-   "compiler"

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ interface ConfigJson {
 	 */
 	authors: string[]
 	/**
-	 * A path relative to the project roots that points to a logo representing the author group
+	 * A path relative to the project root that points to a logo representing the author group
 	 *
 	 * @example "./my-logo.png"
 	 */

--- a/README.md
+++ b/README.md
@@ -23,13 +23,7 @@ interface ConfigJson {
 	 *
 	 * @example ["solvedDev", "Joel ant 05"]
 	 */
-	authors: string[]
-	/**
-	 * A path relative to the project root that points to a logo representing the author group
-	 *
-	 * @example "./my-logo.png"
-	 */
-	authorGroupLogo?: string
+	authors: (string | AuthorData)[]
 
 	/**
 	 * The Minecraft version this project targets
@@ -105,6 +99,22 @@ interface PackDefinition {
 	 * String to add to a tool's collected data
 	 */
 	include: string[]
+}
+
+interface AuthorData {
+	/**
+	 * Name of the author
+	 *
+	 * @example "solvedDev"
+	 */
+	name: string
+	/**
+	 * Path to an image (relative to the project root) that serves as an icon for this author. 
+	 * Tools should support ".png" & ".jpg" images
+	 *
+	 * @example "./meta/icons/solvedDev.png"
+	 */
+	logo?: string
 }
 ```
 


### PR DESCRIPTION
## Motivation
Some tools may want to use a logo that represents the group of authors working on a project. This could be useful for e.g. automatically putting a watermark on marketing assets.

## Proposal
Add a new optional property to the project config: `authorGroupLogo`. Its value would be a file path (relative to the project root) that points to a logo for the group of authors working on the project.

## Alternatives
I have considered making the authors array instead also accept an array of objects (` { "name": "solvedDev", "logo": "./logos/solvedDev.png" } `) but that defeats the purpose of this change because we need a single logo representing the whole group of authors, not a logo for each author.